### PR TITLE
Quick PR to remove unused env files

### DIFF
--- a/envs/bbmap.yml
+++ b/envs/bbmap.yml
@@ -1,6 +1,0 @@
-channels:
-   - conda-forge
-   - bioconda
-   - defaults
-dependencies:
-   - bbmap=39.01

--- a/envs/codonw.yml
+++ b/envs/codonw.yml
@@ -1,6 +1,0 @@
-channels:
-   - conda-forge
-   - bioconda
-   - defaults
-dependencies:
-   - codonw=1.4.4


### PR DESCRIPTION
I deleted the codonw and bbmap compositional scan rules because they were too biased by length and because, in the case of codonw, emboss was better. This pr removes the env .yml files that are no longer needed